### PR TITLE
No bank a/b for clip launcher & allow clips to turn off with shift

### DIFF
--- a/controller-scripts/akai-mpk2-series/MPK225.control.js
+++ b/controller-scripts/akai-mpk2-series/MPK225.control.js
@@ -41,7 +41,7 @@ function init()
     // transport.isArrangerRecordEnabled().markInterested();
     // transport.isClipLauncherOverdubEnabled().markInterested();
 	application = host.createApplicationSection();
-    trackBank = host.createMainTrackBank(8, 2, 16);
+    trackBank = host.createMainTrackBank(4, 2, 16);
     sceneLaunchTrackBank = host.createTrackBank(1,0,64);
 
 
@@ -60,7 +60,7 @@ function init()
     trackBank.getClipLauncherScenes().addNameObserver(sceneLaunchObs());
 
 
-	for (var p = 0; p < 8; p++)
+	for (var p = 0; p < 4; p++)
 	{
 		var macro = primaryDevice.getMacro(p).getAmount();
 		var parameter = cursorDevice.getParameter(p);

--- a/controller-scripts/akai-mpk2-series/MPK2_25PadClipLaunch.js
+++ b/controller-scripts/akai-mpk2-series/MPK2_25PadClipLaunch.js
@@ -1,27 +1,20 @@
 var PadClipLauncher = new PadMode();
 
 
-var ClipBanks = {
-    Bank_A:0x01,
-    Bank_B:0x02
-};
+// Removed bank A/B functionality - now works with 4 tracks only
 
 
 PadClipLauncher.init = function() {
     if (displayHelpText) {
-        if (activeClipBank == ClipBanks.Bank_A) {
-            host.showPopupNotification("Pads: Clip Launch: 1 - 4");
-        }
-        else {
-            host.showPopupNotification("Pads: Clip Launch: 5 - 8");
-        }
+        host.showPopupNotification("Pads: Clip Launch: Tracks 1 - 4");
     }
 
     PadNotes.setShouldConsumeEvents(false);
     PadNotes.setKeyTranslationTable(PadMIDITable.OFF);
 
-    for(var x = 0; x < 8; x++) {
-        for (var y = 0; y < 8; y++) {
+    // Update LEDs for 4 tracks only (16x4 grid)
+    for(var x = 0; x < 4; x++) {
+        for (var y = 0; y < 16; y++) {
             PadClipLauncher.updateClipLED(x,y);
         }
     }
@@ -29,12 +22,15 @@ PadClipLauncher.init = function() {
 
 PadClipLauncher.handleMIDI = function (data1,data2) {
     var pressed = data2 > 0;
-    var trackAdd = 0;
-    activeClipBank == ClipBanks.Bank_A ? trackAdd = 0 : trackAdd = 4;
     if (pressed == true) {
-        var track = ((data1 - 36) % 4) + trackAdd;
+        // Map pad to track (0-3) and clip slot
+        var track = (data1 - 36) % 4;
         var clip = PadClipLauncher.getClipForMidiNote(data1);
+      if (shifted) {
+        trackBank.getTrack(track).stop();
+      } else {
         trackBank.getTrack(track).getClipLauncherSlots().launch(clip);
+      }
     }
 }
 
@@ -54,13 +50,12 @@ PadClipLauncher.clipPlayingObs = function(track,slot,isPlaying) {
     this.updateClipLED(track,slot);
 }
 
-PadClipLauncher.getPadFromTrackSlot = function (track,slot, bank) {
+PadClipLauncher.getPadFromTrackSlot = function (track,slot) {
     
     var Pad;
     var newslot;
 
-    if (bank == ClipBanks.Bank_B) { track = track - 4; }
-
+    // Simplified mapping for 4 tracks only
     if ( slot < 2) {
         newslot = Math.abs(slot - 1);
         Pad = track + (newslot * 4);
@@ -86,8 +81,9 @@ PadClipLauncher.getPadFromTrackSlot = function (track,slot, bank) {
 
 PadClipLauncher.updateClipLED = function(track, slot) {
     
-    if ( track < 4 && activeClipBank == ClipBanks.Bank_A)  {
-        Pad = this.getPadFromTrackSlot(track,slot,activeClipBank);
+    // Only handle tracks 0-3 (4 tracks total)
+    if ( track < 4 )  {
+        Pad = this.getPadFromTrackSlot(track,slot);
         var clipData = clipSlots[track][slot];
         if(clipData.recording == true) {
             lightPad (padColors['Red'],Pad,"Off");
@@ -97,22 +93,6 @@ PadClipLauncher.updateClipLED = function(track, slot) {
             lightPad (padColors['Green'],Pad,"Off");
         }
 
-        else {
-            lightPad (clipData.color,Pad,"Off");
-        }
-    }
-
-    else if ( track > 3 && activeClipBank == ClipBanks.Bank_B)  {
-        Pad = this.getPadFromTrackSlot(track,slot,activeClipBank);
-        var clipData = clipSlots[track][slot];
-        if(clipData.recording == true) {
-            lightPad (padColors['Red'],Pad,"Off");
-        }
-        
-        else if(clipData.playing == true) {
-            lightPad (padColors['Green'],Pad,"Off");
-        }
-        
         else {
             lightPad (clipData.color,Pad,"Off");
         }

--- a/controller-scripts/akai-mpk2-series/MPK2_common.js
+++ b/controller-scripts/akai-mpk2-series/MPK2_common.js
@@ -65,15 +65,14 @@ var S_225_BankC = 106;
 /* Mode defines*/
 var usingDrumMachine = false;
 var shifted = false;
-var activeClipBank;
 var displayHelpText = true;
 
 
 /* arrays to keep track of track states */
-var armed = initArray(0, 8);
-var muted = initArray(0, 8);
-var soloed = initArray(0, 8);
-var clipSlots = create2DArray(8,16);
+var armed = initArray(0, 4);
+var muted = initArray(0, 4);
+var soloed = initArray(0, 4);
+var clipSlots = create2DArray(4,16);
 
 
 var drumKeys = initArray(false,128);
@@ -226,7 +225,8 @@ function setSwitchLED(swich, bank, value) {
 }
 
 function updateButtonLeds() {
-    for (var x = 0; x < 8; x++) {
+    // This is updating the LED pads on the controller; there are 8 pads to get the status for
+    for (var x = 0; x < 4; x++) {
         if (shifted == false)  {
             if ( PRODUCT_ID == MPK225_PID) {
                 setSwitchLED(x + S_225_BankB,bankAStatus,armed[x]);
@@ -272,7 +272,7 @@ function cursorTrackpitchObs() {
 }
 
 function initClipArray() {
-    for (var x = 0; x < 8; x++) {
+    for (var x = 0; x < 4; x++) {
         for (var y = 0; y < 16; y++) {
             newClipData = new padSceneData();
             newClipData.playing = false;
@@ -409,13 +409,9 @@ function onMidi(status, data1, data2)
                     setActivePadMode(PadInstrument);
                 }
                 if(data1 - S1 == 1) {
-                    activeClipBank = ClipBanks.Bank_A;
-                    println("just set active to " + activeClipBank);
                     setActivePadMode(PadClipLauncher);
                 }
                 else if(data1 - S1 == 2) {
-                    activeClipBank = ClipBanks.Bank_B;
-                    println("just set active to " + activeClipBank);
                     setActivePadMode(PadClipLauncher);
                 }
                 else if(data1 - S1 == 3) {


### PR DESCRIPTION
## summary
- remove the clip bank a/b from the control bank; I prefer using the `>>` and `<<` overrides to bank tracks within 1 control bank mode rather than toggle between control banks to move the grid